### PR TITLE
Update dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,4 +9,4 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-      time: "00:00"
+      time: "01:01"


### PR DESCRIPTION
`00:00` looks broken, dependabot does not run on time. Try this new time, and monitor that dependabot check runs on time for at least 3 days.