### PR TITLE
Update dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,4 +9,3 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-      time: "01:01"


### PR DESCRIPTION
I believe dependabot does not run daily after time specified on config. There was no check since last two days on discord.ts repo. So, I think it's best to remove this config for now.